### PR TITLE
修复 wechat devtools 自定义远程端口配置文件不生效问题 + 更新 wechat devtools android 使用文档

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -42,7 +42,7 @@ const getOpenId = async ({ devtools, openIdSet }) => {
         openIdSet: new Set(),
     };
     if (consts_1.config.devtools) {
-        ctx.devtools = new cdp_1.WechatDevtools();
+        ctx.devtools = new cdp_1.WechatDevtools(consts_1.config.devtools);
         await ctx.devtools.init();
     }
     for (;;) {

--- a/docs/DevtoolsProtocol.md
+++ b/docs/DevtoolsProtocol.md
@@ -36,10 +36,7 @@ USB/Wireless debugging is required to be enabled.
 
 In WeChat browser:
 
-1. Open [debugmm.qq.com/?forcex5=true](debugmm.qq.com/?forcex5=true) to enable x5 core.
-2. Open [http://debugtbs.qq.com/](http://debugtbs.qq.com/) to install x5 core.
-3. Open [http://debugx5.qq.com/](http://debugx5.qq.com/). In `信息` tab, check option `打开TBS内核Inspector调试功能`.
-4. Restart WeChat.
+1. Open <http://debugxweb.qq.com/?inspector=true> and don't close it
 
 Check your `adb` connections:
 
@@ -52,10 +49,9 @@ List of devices attached
 Forward to localhost:
 
 ```shell
-# stop WeChat instance first
-$ adb shell am force-stop com.tencent.mm
-# after manually start WeChat:
-$ adb shell ps | grep com.tencent.mm:toolsmp | awk '{print $2}' | xargs -I @ adb -s <DEVICE_NAME> forward tcp:<PORT> localabstract:webview_devtools_remote_@
+unix_sockets=$(adb shell "cat /proc/net/unix")
+devtools_port=$(echo "$unix_sockets" | grep -o 'webview_devtools_remote_[0-9]*' | grep -o '[0-9]*')
+adb -s <DEVICE_NAME> forward tcp:<PORT> localabstract:webview_devtools_remote_$devtools_port
 ```
 
 ## Configuration

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ const getOpenId = async ({ devtools, openIdSet }: IContext) => {
     openIdSet: new Set(),
   };
   if (config.devtools) {
-    ctx.devtools = new WechatDevtools();
+    ctx.devtools = new WechatDevtools(config.devtools);
     await ctx.devtools.init();
   }
   for (;;) {


### PR DESCRIPTION
配置文件的参数没传进构造函数里导致一直用的是 devtools 写死的默认参数。我猜这个功能更新到现在甚至没人用过才没发现……

原来安卓调试的步骤已经无效了，新方法参考 <https://developers.weixin.qq.com/community/develop/article/doc/0004ea5f0c08505721ffa70f951413>

另外 Windows 桌面端微信的方法似乎也无效了，大部分网上的方法都是类似这篇文章：<https://www.cnblogs.com/conne/p/15884968.html> 里的调试方法，但是似乎现在的微信强制了不让从命令行带参数启动（即 `-remote-debugging-port=` 的参数自动忽略了），所以即使根据文章中的方法可以从微信内置浏览器中打开 devtools 也无法将 devtools 暴露在远程端口，所以 cdp 部分也用不上了，似乎也没有更好的解决方案……（除非手动 Hook 微信客户端）

目前暂时可用的全自动方案还是把安卓机开着挂微信内置浏览器